### PR TITLE
feat: change version for angular 16 release

### DIFF
--- a/build/tasks/NpmPublish.cs
+++ b/build/tasks/NpmPublish.cs
@@ -53,8 +53,11 @@ namespace Build.tasks
 
         private void PublishNpm(BuildContext context, string distFolder)
         {
-            NpmPublishSettings settings = new NpmPublishSettings();
-            settings.WorkingDirectory = context.Environment.WorkingDirectory.Combine(context.ProjectDirectory.ToDirectoryPath()).Combine(distFolder.ToDirectoryPath());
+            NpmPublishSettings settings = new NpmPublishSettings()
+            {
+                Access = NpmPublishAccess.Public,
+                WorkingDirectory = context.Environment.WorkingDirectory.Combine(context.ProjectDirectory.ToDirectoryPath()).Combine(distFolder.ToDirectoryPath())
+            };
 
             context.NpmPublish(settings);
         }

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/package.json
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleangularcontrols/sac-bootstrap3",
-  "version": "13.0.0-rc.1",
+  "version": "16.0.0-rc.1",
   "peerDependencies": {
     "@angular/common": "^16.0.0",
     "@angular/core": "^16.0.0",

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap4/package.json
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleangularcontrols/sac-bootstrap4",
-  "version": "13.0.0-rc.1",
+  "version": "16.0.0-rc.1",
   "peerDependencies": {
     "@angular/common": "^16.0.0",
     "@angular/core": "^16.0.0",

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap5/package.json
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleangularcontrols/sac-bootstrap5",
-  "version": "13.0.0-rc.1",
+  "version": "16.0.0-rc.1",
   "peerDependencies": {
     "@angular/common": "^16.0.0",
     "@angular/core": "^16.0.0",

--- a/ch.jnetwork.sac-controls/projects/sac-common/package.json
+++ b/ch.jnetwork.sac-controls/projects/sac-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleangularcontrols/sac-common",
-  "version": "13.0.0-rc.1",
+  "version": "16.0.0-rc.1",
   "homepage": "https://github.com/simpleangularcontrols/simpleangularcontrols",
   "peerDependencies": {
     "@angular/common": "^16.0.0",


### PR DESCRIPTION
chore: change package major version to 16 to be compliant with angular 16
fix: change publish mode to public to push to npmjs