### PR TITLE
fix: close contextmenu on destroy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,9 +27,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Angular Version**
- - Version: [13.x.x]
- - Component Version: [13.x.x.]
- - Form Technolog: [e.g. template driven, reactive forms]
+ - Version: [13.x.x,16.x.x]
+ - Component Version: [13.x.x,16.x.x]
+ - Form Technolog: [template driven,reactive forms]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "angular/13.2.x", "angular/*" ]
+    branches: [ "angular/16.x.x", "angular/*" ]
   pull_request:
-    branches: [ "angular/13.2.x", "angular/*" ]
+    branches: [ "angular/16.x.x", "angular/*" ]
   schedule:
     - cron: '37 7 * * 4'
 
@@ -64,7 +64,6 @@ jobs:
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.html
@@ -1,6 +1,5 @@
 <h2>Tabs</h2>
 <form #myForm="sacform" labelsize="3">
-
   <sac-tab name="tab1">
     <sac-tabitem id="home1" label="Home">
       <ng-template>
@@ -10,6 +9,14 @@
     <sac-tabitem id="profile1" label="Profile">
       <ng-template>
         <p>Tab 2</p>
+        <p>Context Menu</p>
+        <div>
+          <sac-contextmenu>
+            <sac-contextmenubutton text="Action 1"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 2"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 3"></sac-contextmenubutton>
+          </sac-contextmenu>
+        </div>
       </ng-template>
     </sac-tabitem>
     <sac-tabitem id="messages1" label="Messages">
@@ -46,5 +53,4 @@
       </ng-template>
     </sac-tabitem>
   </sac-tab>
-
 </form>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.ts
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.ts
@@ -1,17 +1,20 @@
 import { Component } from '@angular/core';
-import { SACBootstrap4FormModule, SACBootstrap4TabsModule } from '@simpleangularcontrols/sac-bootstrap4';
 import { FormsModule } from '@angular/forms';
+import {
+  SACBootstrap4ContextmenuModule,
+  SACBootstrap4FormModule,
+  SACBootstrap4TabsModule,
+} from '@simpleangularcontrols/sac-bootstrap4';
 
 @Component({
-    selector: 'app-tabs',
-    templateUrl: './tabs.component.html',
-    standalone: true,
-    imports: [
-        FormsModule,
-        SACBootstrap4FormModule,
-        SACBootstrap4TabsModule,
-    ],
+  selector: 'app-tabs',
+  templateUrl: './tabs.component.html',
+  standalone: true,
+  imports: [
+    FormsModule,
+    SACBootstrap4FormModule,
+    SACBootstrap4TabsModule,
+    SACBootstrap4ContextmenuModule,
+  ],
 })
-export class DemoTabsComponent {
-
-}
+export class DemoTabsComponent {}

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/contextmenu/contextmenu.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/contextmenu/contextmenu.component.html
@@ -10,7 +10,6 @@
       <sac-contextmenubutton text="Action 3"></sac-contextmenubutton>
     </sac-contextmenu>
   </div>
-
   <p>Button Right Aligned</p>
   <div class="d-flex flex-row-reverse">
     <div>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.html
@@ -1,6 +1,5 @@
 <h2>Tabs</h2>
 <form #myForm="sacform" labelsize="3">
-
   <sac-tab name="tab1">
     <sac-tabitem id="home1" label="Home">
       <ng-template>
@@ -10,6 +9,14 @@
     <sac-tabitem id="profile1" label="Profile">
       <ng-template>
         <p>Tab 2</p>
+        <p>Context Menu</p>
+        <div>
+          <sac-contextmenu>
+            <sac-contextmenubutton text="Action 1"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 2"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 3"></sac-contextmenubutton>
+          </sac-contextmenu>
+        </div>
       </ng-template>
     </sac-tabitem>
     <sac-tabitem id="messages1" label="Messages">
@@ -46,5 +53,4 @@
       </ng-template>
     </sac-tabitem>
   </sac-tab>
-
 </form>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.ts
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.ts
@@ -1,17 +1,20 @@
 import { Component } from '@angular/core';
-import { SACBootstrap5FormModule, SACBootstrap5TabsModule } from '@simpleangularcontrols/sac-bootstrap5';
+import {
+  SACBootstrap5ContextmenuModule,
+  SACBootstrap5FormModule,
+  SACBootstrap5TabsModule,
+} from '@simpleangularcontrols/sac-bootstrap5';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-    selector: 'app-tabs',
-    templateUrl: './tabs.component.html',
-    standalone: true,
-    imports: [
-        FormsModule,
-        SACBootstrap5FormModule,
-        SACBootstrap5TabsModule,
-    ],
+  selector: 'app-tabs',
+  templateUrl: './tabs.component.html',
+  standalone: true,
+  imports: [
+    FormsModule,
+    SACBootstrap5FormModule,
+    SACBootstrap5TabsModule,
+    SACBootstrap5ContextmenuModule,
+  ],
 })
-export class DemoTabsComponent {
-
-}
+export class DemoTabsComponent {}

--- a/ch.jnetwork.sac-controls/projects/sac-common/src/controls/contextmenu/contextmenu.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-common/src/controls/contextmenu/contextmenu.ts
@@ -173,6 +173,10 @@ export class SacContextmenuCommon implements OnDestroy {
    * Event wenn Component entfernt wird.
    */
   public ngOnDestroy(): void {
+    if (this.isopen) {
+      this.close();
+    }
+
     this.zoneSubscription.unsubscribe();
   }
 

--- a/ch.jnetwork.sac.code-workspace
+++ b/ch.jnetwork.sac.code-workspace
@@ -11,6 +11,7 @@
 		}
 	],
 	"settings": {
+		"window.title": "Simple Angular Controls Ng16",
 		"tsco.addMemberCountInRegionName": false,
 		"editor.codeActionsOnSave": {
 			"source.organizeImports": "always"


### PR DESCRIPTION
fixed (#87): ContextMenu in tabs persists