### PR TITLE
fix: close contextmenu on destroy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,9 +27,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Angular Version**
- - Version: [13.x.x]
- - Component Version: [13.x.x.]
- - Form Technolog: [e.g. template driven, reactive forms]
+ - Version: [13.x.x,16.x.x]
+ - Component Version: [13.x.x,16.x.x]
+ - Form Technolog: [template driven,reactive forms]
 
 **Additional context**
 Add any other context about the problem here.

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.html
@@ -1,6 +1,5 @@
 <h2>Tabs</h2>
 <form #myForm="sacform" labelsize="3">
-
   <sac-tab name="tab1">
     <sac-tabitem id="home1" label="Home">
       <ng-template>
@@ -10,6 +9,14 @@
     <sac-tabitem id="profile1" label="Profile">
       <ng-template>
         <p>Tab 2</p>
+        <p>Context Menu</p>
+        <div>
+          <sac-contextmenu>
+            <sac-contextmenubutton text="Action 1"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 2"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 3"></sac-contextmenubutton>
+          </sac-contextmenu>
+        </div>
       </ng-template>
     </sac-tabitem>
     <sac-tabitem id="messages1" label="Messages">
@@ -46,5 +53,4 @@
       </ng-template>
     </sac-tabitem>
   </sac-tab>
-
 </form>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.ts
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.component.ts
@@ -4,6 +4,4 @@ import { Component } from '@angular/core';
   selector: 'app-tabs',
   templateUrl: './tabs.component.html',
 })
-export class DemoTabsComponent {
-
-}
+export class DemoTabsComponent {}

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.module.ts
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/tabs/tabs.module.ts
@@ -2,8 +2,9 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  SACBootstrap4TabsModule,
+  SACBootstrap4ContextmenuModule,
   SACBootstrap4FormModule,
+  SACBootstrap4TabsModule,
   SACBootstrap4ValidationSummaryModule,
 } from '@simpleangularcontrols/sac-bootstrap4';
 import { TabsRoutingModule } from './tabs-routing.module';
@@ -18,6 +19,7 @@ import { DemoTabsComponent } from './tabs.component';
     SACBootstrap4TabsModule,
     SACBootstrap4ValidationSummaryModule,
     SACBootstrap4TabsModule,
+    SACBootstrap4ContextmenuModule,
   ],
 })
 export class TabsModule {}

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/contextmenu/contextmenu.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/contextmenu/contextmenu.component.html
@@ -10,7 +10,6 @@
       <sac-contextmenubutton text="Action 3"></sac-contextmenubutton>
     </sac-contextmenu>
   </div>
-
   <p>Button Right Aligned</p>
   <div class="d-flex flex-row-reverse">
     <div>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.html
@@ -1,6 +1,5 @@
 <h2>Tabs</h2>
 <form #myForm="sacform" labelsize="3">
-
   <sac-tab name="tab1">
     <sac-tabitem id="home1" label="Home">
       <ng-template>
@@ -10,6 +9,14 @@
     <sac-tabitem id="profile1" label="Profile">
       <ng-template>
         <p>Tab 2</p>
+        <p>Context Menu</p>
+        <div>
+          <sac-contextmenu>
+            <sac-contextmenubutton text="Action 1"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 2"></sac-contextmenubutton>
+            <sac-contextmenubutton text="Action 3"></sac-contextmenubutton>
+          </sac-contextmenu>
+        </div>
       </ng-template>
     </sac-tabitem>
     <sac-tabitem id="messages1" label="Messages">
@@ -46,5 +53,4 @@
       </ng-template>
     </sac-tabitem>
   </sac-tab>
-
 </form>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.ts
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.component.ts
@@ -4,6 +4,4 @@ import { Component } from '@angular/core';
   selector: 'app-tabs',
   templateUrl: './tabs.component.html',
 })
-export class DemoTabsComponent {
-
-}
+export class DemoTabsComponent {}

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.module.ts
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/tabs/tabs.module.ts
@@ -2,8 +2,9 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  SACBootstrap5TabsModule,
+  SACBootstrap5ContextmenuModule,
   SACBootstrap5FormModule,
+  SACBootstrap5TabsModule,
   SACBootstrap5ValidationSummaryModule,
 } from '@simpleangularcontrols/sac-bootstrap5';
 import { TabsRoutingModule } from './tabs-routing.module';
@@ -18,6 +19,7 @@ import { DemoTabsComponent } from './tabs.component';
     SACBootstrap5TabsModule,
     SACBootstrap5ValidationSummaryModule,
     SACBootstrap5TabsModule,
+    SACBootstrap5ContextmenuModule,
   ],
 })
 export class TabsModule {}

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/tabs/tabs.module.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/tabs/tabs.module.ts
@@ -1,13 +1,11 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { SacTabComponent } from './tab';
 import { SacTabItemComponent } from './tabitem';
 
 @NgModule({
   declarations: [SacTabComponent, SacTabItemComponent],
-  imports: [
-    CommonModule
-  ],
-  exports: [SacTabComponent, SacTabItemComponent]
+  imports: [CommonModule],
+  exports: [SacTabComponent, SacTabItemComponent],
 })
-export class SACBootstrap5TabsModule { }
+export class SACBootstrap5TabsModule {}

--- a/ch.jnetwork.sac-controls/projects/sac-common/src/controls/contextmenu/contextmenu.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-common/src/controls/contextmenu/contextmenu.ts
@@ -173,6 +173,10 @@ export class SacContextmenuCommon implements OnDestroy {
    * Event wenn Component entfernt wird.
    */
   public ngOnDestroy(): void {
+    if (this.isopen) {
+      this.close();
+    }
+
     this.zoneSubscription.unsubscribe();
   }
 

--- a/ch.jnetwork.sac.code-workspace
+++ b/ch.jnetwork.sac.code-workspace
@@ -11,6 +11,7 @@
 		}
 	],
 	"settings": {
+		"window.title": "Simple Angular Controls Ng13",
 		"tsco.addMemberCountInRegionName": false,
 		"editor.codeActionsOnSave": {
 			"source.organizeImports": "always"


### PR DESCRIPTION
fixed (#87): ContextMenu in tabs persists