### PR TITLE
fix: Spacing between Buttons in Confirm Dialog cannot be customized

### DIFF
--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap3/src/styles.scss
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap3/src/styles.scss
@@ -24,7 +24,7 @@
     border: 1px solid red;
   }
 
-  .day-disabled{
+  .day-disabled {
     color: gray;
   }
 }

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/buttons/button.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/buttons/button.ts
@@ -1,5 +1,5 @@
 import { CommonModule, NgClass, NgIf } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { SacButtonCommon } from '@simpleangularcontrols/sac-common';
 
 @Component({
@@ -7,5 +7,7 @@ import { SacButtonCommon } from '@simpleangularcontrols/sac-common';
   templateUrl: './button.html',
   standalone: true,
   imports: [NgIf, NgClass, CommonModule],
+  styles: ['sac-button+sac-button {margin-left: 5px}'], // Workaround: Abstand zwischen 2 Buttons setzen, da Boostrap3 nicht mit Host Items umgehen kann
+  encapsulation: ViewEncapsulation.None, // Workaround: Abstand zwischen 2 Buttons setzen, da Boostrap3 nicht mit Host Items umgehen kann
 })
 export class SacButtonComponent extends SacButtonCommon {}

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/confirm/confirm.html
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/confirm/confirm.html
@@ -20,7 +20,6 @@
         [text]="button.text"
         [role]="button.role || 'default'"
         (clicked)="confirm(button.key)"
-        style="margin-left: 15px"
       ></sac-button>
     </ng-container>
   </div>


### PR DESCRIPTION
Ticket #133 