### PR TITLE
feat (#358): Add Custom Default Icons for GridButton

### DIFF
--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap3/src/app/grid/grid.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap3/src/app/grid/grid.component.html
@@ -12,7 +12,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 name="editrow"
                 icon="edit"
@@ -23,12 +23,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -68,7 +68,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -77,12 +77,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -123,7 +123,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -132,12 +132,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -178,7 +178,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -187,12 +187,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -232,7 +232,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -241,12 +241,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -285,7 +285,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -294,12 +294,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -345,7 +345,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="85px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -354,12 +354,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap3/src/styles.scss
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap3/src/styles.scss
@@ -38,3 +38,8 @@
         }
     }
 }
+
+// Custom Disabled Style for FA Icons
+.fa.disabled {
+    color: lightgrey;
+}

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/grid/grid.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/app/grid/grid.component.html
@@ -12,7 +12,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 name="editrow"
                 icon="edit"
@@ -23,12 +23,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -68,7 +68,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -77,12 +77,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -123,7 +123,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -132,12 +132,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -178,7 +178,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -187,12 +187,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -232,7 +232,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -241,12 +241,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -285,7 +285,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -294,12 +294,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -345,7 +345,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -354,12 +354,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/styles.scss
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap4/src/styles.scss
@@ -1,24 +1,29 @@
 /* You can add global styles to this file, and also import other style files */
 .calendar-selector {
-  .day-selected {
-    font-weight: bold;
-  }
+    .day-selected {
+        font-weight: bold;
+    }
 
-  .day-new {
-    background-color: blue;
-    color: white;
-  }
+    .day-new {
+        background-color: blue;
+        color: white;
+    }
 
-  .day-current {
-    border: 1px solid red;
-  }
+    .day-current {
+        border: 1px solid red;
+    }
 }
 
 .tox {
-  &.tox-tinymce-aux {
-    z-index: 900;
-    .tox-dialog-wrap {
-      z-index: 800;
+    &.tox-tinymce-aux {
+        z-index: 900;
+        .tox-dialog-wrap {
+            z-index: 800;
+        }
     }
-  }
+}
+
+// Custom Disabled Style for FA Icons
+.fa.disabled {
+    color: lightgrey;
 }

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/grid/grid.component.html
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/app/grid/grid.component.html
@@ -12,7 +12,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 name="editrow"
                 icon="edit"
@@ -23,12 +23,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -68,7 +68,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -77,12 +77,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -123,7 +123,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -132,12 +132,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -178,7 +178,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -187,12 +187,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -232,7 +232,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -241,12 +241,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -285,7 +285,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -294,12 +294,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>
@@ -345,7 +345,7 @@
         <sac-gridcolumnaction
             name="editCol"
             [type]="type"
-            width="78px">
+            width="98px">
             <sac-gridbutton
                 icon="edit"
                 (clicked)="action($event)"
@@ -354,12 +354,12 @@
                 icon="delete"
                 (clicked)="action($event)"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridbutton
-                iconstyle="sprite"
-                icon="icon-sprite-base-main_info"
+                iconstyle="fa"
+                icon="fa-info-circle"
                 isdisabled="true"
                 (clicked)="action('info')"></sac-gridbutton>
             <sac-gridimage iconstyle="sprite icon-sprite-base-main_info"></sac-gridimage>

--- a/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/styles.scss
+++ b/ch.jnetwork.sac-controls/projects/demo-bootstrap5/src/styles.scss
@@ -1,25 +1,29 @@
 /* You can add global styles to this file, and also import other style files */
 .calendar-selector {
     .day-selected {
-      font-weight: bold;
+        font-weight: bold;
     }
-  
+
     .day-new {
-      background-color: blue;
-      color: white;
+        background-color: blue;
+        color: white;
     }
-  
+
     .day-current {
-      border: 1px solid red;
+        border: 1px solid red;
     }
-  }
-  
-  .tox {
+}
+
+.tox {
     &.tox-tinymce-aux {
-      z-index: 900;
-      .tox-dialog-wrap {
-        z-index: 800;
-      }
+        z-index: 900;
+        .tox-dialog-wrap {
+            z-index: 800;
+        }
     }
-  }
-  
+}
+
+// Custom Disabled Style for FA Icons
+.fa.disabled {
+    color: lightgrey;
+}

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/grid/gridbutton.md
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/grid/gridbutton.md
@@ -17,3 +17,15 @@
 ```html
 <ngGridButton iconstyle="sprite" icon="icon-sprite-base-main_info" (clicked)="action('info')"></ngGridButton>
 ```
+
+## Change default icons for Edit and Delete
+
+To customize the CSS classes for the edit and delete icon mode of the grid button, the options `GridButtonDefaultEditIconSet` and `GridButtonDefaultEditIcon` or `GridButtonDefaultDeleteIconSet` and `GridButtonDefaultDeleteIcon` must be adjusted in IconService. To do this, you must create and register your own implementation of IconService.
+
+## Customize disabled suffix
+
+The suffix can be customized via the `GridButtonDisabledIconSuffix` property in IconService. To make a customization, you must implement and register your own service.
+
+To use the suffix as a suffix, the setting must be defined as a whole string (e.g., `_disabled`). This then generates the following disabled icon: `fa-pen_disabled`
+
+If the suffix is to be used as a separate CSS class, a space must be inserted at the beginning (e.g., ` disabled`). This then generates the following icon: `fa-pen d

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/grid/gridbutton.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/grid/gridbutton.ts
@@ -1,44 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { SacGridButtonCommon } from '@simpleangularcontrols/sac-common';
 
 /**
  * Grid Action Button
  */
 @Component({
-  selector: 'sac-gridbutton',
-  templateUrl: './gridbutton.html',
+    selector: 'sac-gridbutton',
+    templateUrl: './gridbutton.html',
 })
 export class SacGridButtonComponent extends SacGridButtonCommon {
-  // #region Public Methods
+    // #region Constructors
 
-  /**
-   * Returns the icon for the button
-   */
-  public getIconClass(): string {
-    let iconset: string = this.iconstyle;
-    let iconcss: string = this.icon;
-
-    if (iconset === '') {
-      switch (this.icon) {
-        case 'edit':
-          iconset = 'sprite';
-          iconcss = 'icon-sprite-base-main_edit';
-          break;
-        case 'delete':
-          iconset = 'sprite';
-          iconcss = 'icon-sprite-base-main_delete';
-          break;
-      }
+    /**
+     * Construtor
+     *
+     * @param injector Injector to resolve  icons
+     */
+    constructor(injector: Injector) {
+        super(injector);
     }
 
-    if (this._isdisabledvalue) {
-      iconcss += '_disabled';
-    }
-
-    const result = iconset + ' ' + iconcss;
-
-    return result.trim();
-  }
-
-  // #endregion Public Methods
+    // #endregion Constructors
 }

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/grid/gridbutton.md
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/grid/gridbutton.md
@@ -17,3 +17,15 @@
 ```html
 <ngGridButton iconstyle="sprite" icon="icon-sprite-base-main_info" (clicked)="action('info')"></ngGridButton>
 ```
+
+## Change default icons for Edit and Delete
+
+To customize the CSS classes for the edit and delete icon mode of the grid button, the options `GridButtonDefaultEditIconSet` and `GridButtonDefaultEditIcon` or `GridButtonDefaultDeleteIconSet` and `GridButtonDefaultDeleteIcon` must be adjusted in IconService. To do this, you must create and register your own implementation of IconService.
+
+## Customize disabled suffix
+
+The suffix can be customized via the `GridButtonDisabledIconSuffix` property in IconService. To make a customization, you must implement and register your own service.
+
+To use the suffix as a suffix, the setting must be defined as a whole string (e.g., `_disabled`). This then generates the following disabled icon: `fa-pen_disabled`
+
+If the suffix is to be used as a separate CSS class, a space must be inserted at the beginning (e.g., ` disabled`). This then generates the following icon: `fa-pen d

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/grid/gridbutton.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/grid/gridbutton.ts
@@ -1,44 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { SacGridButtonCommon } from '@simpleangularcontrols/sac-common';
 
 /**
  * Grid Action Button
  */
 @Component({
-  selector: 'sac-gridbutton',
-  templateUrl: './gridbutton.html',
+    selector: 'sac-gridbutton',
+    templateUrl: './gridbutton.html',
 })
 export class SacGridButtonComponent extends SacGridButtonCommon {
-  // #region Public Methods
+    // #region Constructors
 
-  /**
-   * Returns the icon for the button
-   */
-  public getIconClass(): string {
-    let iconset: string = this.iconstyle;
-    let iconcss: string = this.icon;
-
-    if (iconset === '') {
-      switch (this.icon) {
-        case 'edit':
-          iconset = 'sprite';
-          iconcss = 'icon-sprite-base-main_edit';
-          break;
-        case 'delete':
-          iconset = 'sprite';
-          iconcss = 'icon-sprite-base-main_delete';
-          break;
-      }
+    /**
+     * Construtor
+     *
+     * @param injector Injector to resolve  icons
+     */
+    constructor(injector: Injector) {
+        super(injector);
     }
 
-    if (this._isdisabledvalue) {
-      iconcss += '_disabled';
-    }
-
-    const result = iconset + ' ' + iconcss;
-
-    return result.trim();
-  }
-
-  // #endregion Public Methods
+    // #endregion Constructors
 }

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/grid/gridbutton.md
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/grid/gridbutton.md
@@ -17,3 +17,15 @@
 ```html
 <ngGridButton iconstyle="sprite" icon="icon-sprite-base-main_info" (clicked)="action('info')"></ngGridButton>
 ```
+
+## Change default icons for Edit and Delete
+
+To customize the CSS classes for the edit and delete icon mode of the grid button, the options `GridButtonDefaultEditIconSet` and `GridButtonDefaultEditIcon` or `GridButtonDefaultDeleteIconSet` and `GridButtonDefaultDeleteIcon` must be adjusted in IconService. To do this, you must create and register your own implementation of IconService.
+
+## Customize disabled suffix
+
+The suffix can be customized via the `GridButtonDisabledIconSuffix` property in IconService. To make a customization, you must implement and register your own service.
+
+To use the suffix as a suffix, the setting must be defined as a whole string (e.g., `_disabled`). This then generates the following disabled icon: `fa-pen_disabled`
+
+If the suffix is to be used as a separate CSS class, a space must be inserted at the beginning (e.g., ` disabled`). This then generates the following icon: `fa-pen d

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/grid/gridbutton.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/grid/gridbutton.ts
@@ -1,44 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, Injector } from '@angular/core';
 import { SacGridButtonCommon } from '@simpleangularcontrols/sac-common';
 
 /**
  * Grid Action Button
  */
 @Component({
-  selector: 'sac-gridbutton',
-  templateUrl: './gridbutton.html',
+    selector: 'sac-gridbutton',
+    templateUrl: './gridbutton.html',
 })
 export class SacGridButtonComponent extends SacGridButtonCommon {
-  // #region Public Methods
+    // #region Constructors
 
-  /**
-   * Returns the icon for the button
-   */
-  public getIconClass(): string {
-    let iconset: string = this.iconstyle;
-    let iconcss: string = this.icon;
-
-    if (iconset === '') {
-      switch (this.icon) {
-        case 'edit':
-          iconset = 'sprite';
-          iconcss = 'icon-sprite-base-main_edit';
-          break;
-        case 'delete':
-          iconset = 'sprite';
-          iconcss = 'icon-sprite-base-main_delete';
-          break;
-      }
+    /**
+     * Construtor
+     *
+     * @param injector Injector to resolve  icons
+     */
+    constructor(injector: Injector) {
+        super(injector);
     }
 
-    if (this._isdisabledvalue) {
-      iconcss += '_disabled';
-    }
-
-    const result = iconset + ' ' + iconcss;
-
-    return result.trim();
-  }
-
-  // #endregion Public Methods
+    // #endregion Constructors
 }

--- a/ch.jnetwork.sac-controls/projects/sac-common/src/controls/grid/gridbutton.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-common/src/controls/grid/gridbutton.ts
@@ -1,4 +1,6 @@
-import { Directive, EventEmitter, Input, Output } from '@angular/core';
+import { ISacIconService } from '../../interfaces/ISacIconService';
+import { SACICON_SERVICE, SacDefaultIconService } from '../../services';
+import { Directive, EventEmitter, Injector, Input, Output } from '@angular/core';
 
 /**
  * Base Grid Action Button
@@ -6,6 +8,11 @@ import { Directive, EventEmitter, Input, Output } from '@angular/core';
 @Directive()
 export class SacGridButtonCommon {
     // #region Properties
+
+    /**
+     * Service for reading standard icon
+     */
+    private iconService: ISacIconService;
 
     /**
      * Button is deactivated
@@ -38,6 +45,19 @@ export class SacGridButtonCommon {
 
     // #endregion Properties
 
+    // #region Constructors
+
+    /**
+     * Constructor
+     *
+     * @param injector Injector to resovle services
+     */
+    constructor(protected readonly injector: Injector) {
+        this.iconService = injector.get(SACICON_SERVICE, new SacDefaultIconService());
+    }
+
+    // #endregion Constructors
+
     // #region Public Getters And Setters
 
     public get isdisabled(): boolean | string {
@@ -69,6 +89,39 @@ export class SacGridButtonCommon {
         if (!this._isdisabledvalue) {
             this.clicked.emit(this.iconstyle);
         }
+    }
+
+    /**
+     * Defines the CSS class for the icon on the button
+     */
+    public getIconClass(): string {
+        let cssclass;
+
+        // Handle Default Icons
+        if (this.iconstyle === '') {
+            switch (this.icon) {
+                case 'edit':
+                    cssclass = `${this.iconService.GridButtonDefaultEditIconSet} ${this.iconService.GridButtonDefaultEditIcon}`;
+                    break;
+                case 'delete':
+                    cssclass = `${this.iconService.GridButtonDefaultDeleteIconSet} ${this.iconService.GridButtonDefaultDeleteIcon}`;
+                    break;
+                default:
+                    cssclass = this.icon;
+                    break;
+            }
+        } else {
+            cssclass = `${this.iconstyle} ${this.icon}`;
+        }
+
+        // trim style
+        cssclass = cssclass.trim();
+
+        if (this._isdisabledvalue) {
+            cssclass += this.iconService.GridButtonDisabledIconSuffix;
+        }
+
+        return cssclass;
     }
 
     // #endregion Public Methods

--- a/ch.jnetwork.sac-controls/projects/sac-common/src/interfaces/ISacIconService.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-common/src/interfaces/ISacIconService.ts
@@ -75,6 +75,31 @@ export interface ISacIconService {
     GenericHelptextIcon: string;
 
     /**
+     * Default Icon Class for Delete Button in Grid
+     */
+    GridButtonDefaultDeleteIcon: string;
+
+    /**
+     * Default IconSet for Delete Button in Grid
+     */
+    GridButtonDefaultDeleteIconSet: string;
+
+    /**
+     * Default Icon Class for Edit Button in Grid
+     */
+    GridButtonDefaultEditIcon: string;
+
+    /**
+     * Default IconSet for Edit Button in Grid
+     */
+    GridButtonDefaultEditIconSet: string;
+
+    /**
+     * Suffix that is added to all icon classes when the button is disabled.
+     */
+    GridButtonDisabledIconSuffix: string;
+
+    /**
      * sort down icon for grid
      */
     GridComponentSortDown: string;

--- a/ch.jnetwork.sac-controls/projects/sac-common/src/services/sac-icon.service.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-common/src/services/sac-icon.service.ts
@@ -92,6 +92,31 @@ export abstract class SacAbstractIconService implements ISacIconService {
     /**
      * @inheritdoc
      */
+    public abstract get GridButtonDefaultDeleteIcon(): string;
+
+    /**
+     * @inheritdoc
+     */
+    public abstract get GridButtonDefaultDeleteIconSet(): string;
+
+    /**
+     * @inheritdoc
+     */
+    public abstract get GridButtonDefaultEditIcon(): string;
+
+    /**
+     * @inheritdoc
+     */
+    public abstract get GridButtonDefaultEditIconSet(): string;
+
+    /**
+     * @inheritdoc
+     */
+    public abstract get GridButtonDisabledIconSuffix(): string;
+
+    /**
+     * @inheritdoc
+     */
     public abstract get GridComponentSortDown(): string;
 
     /**
@@ -270,6 +295,41 @@ export class SacDefaultIconService extends SacAbstractIconService {
      */
     public get GenericHelptextIcon(): string {
         return 'fa fa-info-circle';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public get GridButtonDefaultDeleteIcon(): string {
+        return 'fa-trash';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public get GridButtonDefaultDeleteIconSet(): string {
+        return 'fa';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public get GridButtonDefaultEditIcon(): string {
+        return 'fa-pen';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public get GridButtonDefaultEditIconSet(): string {
+        return 'fa';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public get GridButtonDisabledIconSuffix(): string {
+        return ' disabled';
     }
 
     /**


### PR DESCRIPTION
This change includes breaking changes. To maintain the original state, a separate IconService must be implemented. To do this, the following properties must be defined in the service as shown below:

GridButtonDefaultDeleteIcon: ‘icon-sprite-base-main_delete’;
GridButtonDefaultDeleteIconSet: ‘sprite’;
GridButtonDefaultEditIcon: ‘icon-sprite-base-main_edit’
GridButtonDefaultEditIconSet: ‘sprite’;
GridButtonDisabledIconSuffix: ‘_disabled’

This reconfigures the GridButton to its original state.