### PR TITLE
fix (#374): dropdown should allow numbers and null as emptyvalue

### DIFF
--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/list/dropdown.cy.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/list/dropdown.cy.ts
@@ -409,7 +409,8 @@ describe('SacDropdownComponent', () => {
                         </sac-dropdown>
                     </form>`,
             {
-                imports: [FormsModule, SacFormDirective, SACBootstrap3ListModule, SACBootstrap3LayoutModule],
+                declarations: [SacFormDirective],
+                imports: [FormsModule, SACBootstrap3ListModule, SACBootstrap3LayoutModule],
                 componentProperties: {
                     label: 'My Label',
                     value: 0,
@@ -437,7 +438,8 @@ describe('SacDropdownComponent', () => {
                         </sac-dropdown>
                     </form>`,
             {
-                imports: [FormsModule, SacFormDirective, SACBootstrap3ListModule, SACBootstrap3LayoutModule],
+                declarations: [SacFormDirective],
+                imports: [FormsModule, SACBootstrap3ListModule, SACBootstrap3LayoutModule],
                 componentProperties: {
                     label: 'My Label',
                     value: 'notset',

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/list/dropdown.cy.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap3/src/controls/list/dropdown.cy.ts
@@ -393,4 +393,60 @@ describe('SacDropdownComponent', () => {
 
         cy.shouldHaveDisabledTestAttribute('sac-dropdown > div');
     });
+
+    it('should allow numbers as empty value', () => {
+        cy.mount(
+            `<form>
+                        <sac-dropdown 
+                            name="dropdown" 
+                            [label]="label"
+                            [emptyvalue]="0" 
+                            emptylabel="Please select"
+                            [(ngModel)]="value">
+                            <option [ngValue]="1">Value Item 1</option>
+                            <option [ngValue]="2">Value Item 2</option>
+                            <option [ngValue]="3">Value Item 3</option>
+                        </sac-dropdown>
+                    </form>`,
+            {
+                imports: [FormsModule, SacFormDirective, SACBootstrap3ListModule, SACBootstrap3LayoutModule],
+                componentProperties: {
+                    label: 'My Label',
+                    value: 0,
+                },
+            }
+        );
+
+        cy.shouldHaveLabel('My Label');
+        cy.get('select').find('option:selected').should('have.text', 'Please select');
+        cy.get('select').find('option:selected').should('have.value', '3: 0');
+    });
+
+    it('should allow string as empty value', () => {
+        cy.mount(
+            `<form>
+                        <sac-dropdown 
+                            name="dropdown" 
+                            [label]="label"
+                            emptyvalue="notset" 
+                            emptylabel="Please select"
+                            [(ngModel)]="value">
+                            <option [ngValue]="value1">Value Item 1</option>
+                            <option [ngValue]="value2">Value Item 2</option>
+                            <option [ngValue]="value3">Value Item 3</option>
+                        </sac-dropdown>
+                    </form>`,
+            {
+                imports: [FormsModule, SacFormDirective, SACBootstrap3ListModule, SACBootstrap3LayoutModule],
+                componentProperties: {
+                    label: 'My Label',
+                    value: 'notset',
+                },
+            }
+        );
+
+        cy.shouldHaveLabel('My Label');
+        cy.get('select').find('option:selected').should('have.text', 'Please select');
+        cy.get('select').find('option:selected').should('have.value', '3: notset');
+    });
 });

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/list/dropdown.cy.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/list/dropdown.cy.ts
@@ -451,4 +451,60 @@ describe('SacDropdownComponent', () => {
 
         cy.shouldHaveDisabledTestAttribute('sac-dropdown > div');
     });
+
+    it('should allow numbers as empty value', () => {
+        cy.mount(
+            `<form>
+                    <sac-dropdown 
+                        name="dropdown" 
+                        [label]="label"
+                        [emptyvalue]="0" 
+                        emptylabel="Please select"
+                        [(ngModel)]="value">
+                        <option [ngValue]="1">Value Item 1</option>
+                        <option [ngValue]="2">Value Item 2</option>
+                        <option [ngValue]="3">Value Item 3</option>
+                    </sac-dropdown>
+                </form>`,
+            {
+                imports: [FormsModule, SacFormDirective, SACBootstrap4DropdownModule, SACBootstrap4LayoutModule],
+                componentProperties: {
+                    label: 'My Label',
+                    value: 0,
+                },
+            }
+        );
+
+        cy.shouldHaveLabel('My Label');
+        cy.get('select').find('option:selected').should('have.text', 'Please select');
+        cy.get('select').find('option:selected').should('have.value', '3: 0');
+    });
+
+    it('should allow string as empty value', () => {
+        cy.mount(
+            `<form>
+                    <sac-dropdown 
+                        name="dropdown" 
+                        [label]="label"
+                        emptyvalue="notset" 
+                        emptylabel="Please select"
+                        [(ngModel)]="value">
+                        <option [ngValue]="value1">Value Item 1</option>
+                        <option [ngValue]="value2">Value Item 2</option>
+                        <option [ngValue]="value3">Value Item 3</option>
+                    </sac-dropdown>
+                </form>`,
+            {
+                imports: [FormsModule, SacFormDirective, SACBootstrap4DropdownModule, SACBootstrap4LayoutModule],
+                componentProperties: {
+                    label: 'My Label',
+                    value: 'notset',
+                },
+            }
+        );
+
+        cy.shouldHaveLabel('My Label');
+        cy.get('select').find('option:selected').should('have.text', 'Please select');
+        cy.get('select').find('option:selected').should('have.value', '3: notset');
+    });
 });

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/list/dropdown.cy.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap4/src/controls/list/dropdown.cy.ts
@@ -467,7 +467,8 @@ describe('SacDropdownComponent', () => {
                     </sac-dropdown>
                 </form>`,
             {
-                imports: [FormsModule, SacFormDirective, SACBootstrap4DropdownModule, SACBootstrap4LayoutModule],
+                declarations: [SacFormDirective],
+                imports: [FormsModule, SACBootstrap4DropdownModule, SACBootstrap4LayoutModule],
                 componentProperties: {
                     label: 'My Label',
                     value: 0,
@@ -495,7 +496,8 @@ describe('SacDropdownComponent', () => {
                     </sac-dropdown>
                 </form>`,
             {
-                imports: [FormsModule, SacFormDirective, SACBootstrap4DropdownModule, SACBootstrap4LayoutModule],
+                declarations: [SacFormDirective],
+                imports: [FormsModule, SACBootstrap4DropdownModule, SACBootstrap4LayoutModule],
                 componentProperties: {
                     label: 'My Label',
                     value: 'notset',

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/list/dropdown.cy.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/list/dropdown.cy.ts
@@ -467,7 +467,8 @@ describe('SacDropdownComponent', () => {
                 </sac-dropdown>
             </form>`,
             {
-                imports: [FormsModule, SacFormDirective, SACBootstrap5DropdownModule, SACBootstrap5LayoutModule],
+                declarations: [SacFormDirective],
+                imports: [FormsModule, SACBootstrap5DropdownModule, SACBootstrap5LayoutModule],
                 componentProperties: {
                     label: 'My Label',
                     value: 0,
@@ -495,7 +496,8 @@ describe('SacDropdownComponent', () => {
                 </sac-dropdown>
             </form>`,
             {
-                imports: [FormsModule, SacFormDirective, SACBootstrap5DropdownModule, SACBootstrap5LayoutModule],
+                declarations: [SacFormDirective],
+                imports: [FormsModule, SACBootstrap5DropdownModule, SACBootstrap5LayoutModule],
                 componentProperties: {
                     label: 'My Label',
                     value: 'notset',

--- a/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/list/dropdown.cy.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-bootstrap5/src/controls/list/dropdown.cy.ts
@@ -451,4 +451,60 @@ describe('SacDropdownComponent', () => {
 
         cy.shouldHaveDisabledTestAttribute('sac-dropdown > div');
     });
+
+    it('should allow numbers as empty value', () => {
+        cy.mount(
+            `<form>
+                <sac-dropdown 
+                    name="dropdown" 
+                    [label]="label"
+                    [emptyvalue]="0" 
+                    emptylabel="Please select"
+                    [(ngModel)]="value">
+                    <option [ngValue]="1">Value Item 1</option>
+                    <option [ngValue]="2">Value Item 2</option>
+                    <option [ngValue]="3">Value Item 3</option>
+                </sac-dropdown>
+            </form>`,
+            {
+                imports: [FormsModule, SacFormDirective, SACBootstrap5DropdownModule, SACBootstrap5LayoutModule],
+                componentProperties: {
+                    label: 'My Label',
+                    value: 0,
+                },
+            }
+        );
+
+        cy.shouldHaveLabel('My Label');
+        cy.get('select').find('option:selected').should('have.text', 'Please select');
+        cy.get('select').find('option:selected').should('have.value', '3: 0');
+    });
+
+    it('should allow string as empty value', () => {
+        cy.mount(
+            `<form>
+                <sac-dropdown 
+                    name="dropdown" 
+                    [label]="label"
+                    emptyvalue="notset" 
+                    emptylabel="Please select"
+                    [(ngModel)]="value">
+                    <option [ngValue]="value1">Value Item 1</option>
+                    <option [ngValue]="value2">Value Item 2</option>
+                    <option [ngValue]="value3">Value Item 3</option>
+                </sac-dropdown>
+            </form>`,
+            {
+                imports: [FormsModule, SacFormDirective, SACBootstrap5DropdownModule, SACBootstrap5LayoutModule],
+                componentProperties: {
+                    label: 'My Label',
+                    value: 'notset',
+                },
+            }
+        );
+
+        cy.shouldHaveLabel('My Label');
+        cy.get('select').find('option:selected').should('have.text', 'Please select');
+        cy.get('select').find('option:selected').should('have.value', '3: notset');
+    });
 });

--- a/ch.jnetwork.sac-controls/projects/sac-common/src/controls/list/dropdown.ts
+++ b/ch.jnetwork.sac-controls/projects/sac-common/src/controls/list/dropdown.ts
@@ -35,7 +35,7 @@ export class SacDropdownCommon extends SacBaseSelectControl<any> {
     /**
      * Option Value für Empty Item
      */
-    @Input() public emptyvalue: string = null;
+    @Input() public emptyvalue: string | null | number = null;
 
     /**
      * Resource Key für Validation Message Required bei Control


### PR DESCRIPTION
#374: dropdown should allow numbers and null as emptyvalue